### PR TITLE
chore: ignore pnpm-lock.yaml in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- Adds `.prettierignore` with `pnpm-lock.yaml` to prevent Dependabot PRs from failing the format check