### PR TITLE
chore: switch dependabot to monthly and add reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
     target-branch: "main"
     open-pull-requests-limit: 10
+    reviewers:
+      - "gek0z"
     groups:
       minor-and-patch:
         update-types:
@@ -20,7 +21,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    reviewers:
+      - "gek0z"
     groups:
       all-actions:
         patterns:


### PR DESCRIPTION
## Summary
- Changes dependabot schedule from weekly to monthly for both npm and GitHub Actions
- Adds gek0z as reviewer on all dependabot PRs