### PR TITLE
fix: hide games-since-last-wedgie section when count is omitted

### DIFF
--- a/src/components/stats-for-nerds/StatsForNerds.tsx
+++ b/src/components/stats-for-nerds/StatsForNerds.tsx
@@ -321,8 +321,8 @@ function SeasonComparisonWrapper({ stats }: StatsForNerdsProps) {
 }
 
 function LastWedgieWrapper({ stats }: StatsForNerdsProps) {
-  if (!stats.lastWedgiePlayer) return null;
-  // if (!stats.gamesSinceLastWedgie && !stats.lastWedgiePlayer) return null;
+  if (!stats.lastWedgiePlayer || stats.gamesSinceLastWedgie === undefined)
+    return null;
 
   return (
     <div className="flex w-full max-w-xl flex-col items-center justify-center">


### PR DESCRIPTION
## Summary
- When the season total is ahead of the wedgie list, the server already omits `gamesSinceLastWedgie` from the nerd stats payload, but the UI still rendered the "N GAMES PLAYED SINCE THE LAST [PLAYER]'S WEDGIE" block with a blank number.
- `LastWedgieWrapper` now returns `null` when `gamesSinceLastWedgie` is `undefined`. Uses `=== undefined` so a legitimate count of `0` still renders.
