### PR TITLE
fix: region-targeted GA4 Consent Mode v2

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "~/styles/globals.css";
 import { Suspense } from "react";
+import { headers } from "next/headers";
 import { Inter } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "~/components/ui/toaster";
@@ -7,6 +8,10 @@ import { defaultMetadata } from "~/config/metadata";
 import { GoogleTagManager } from "@next/third-parties/google";
 
 import ConsentBanner from "~/components/shared/ConsentBanner";
+import {
+  CONSENT_REQUIRED_REGIONS,
+  isConsentRequiredCountry,
+} from "~/lib/consent-region";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -15,10 +20,12 @@ const inter = Inter({
 
 export const metadata = defaultMetadata;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const gtmId = process.env.NEXT_PUBLIC_GA_ID!;
+  const country = (await headers()).get("x-vercel-ip-country");
+  const requiresConsent = isConsentRequiredCountry(country);
 
   return (
     <html lang="en" className={`${inter.variable}`}>
@@ -31,22 +38,48 @@ export default function RootLayout({
           property="twitter:image"
           content="https://res.cloudinary.com/wedgietracker/image/upload/v1736700345/assets/social-wedgietracker_bibnbu.jpg"
         />
-        {/* Set consent mode defaults before GTM loads */}
+        {/* Consent Mode v2 — region-targeted defaults, applied before GTM loads */}
         <script
           dangerouslySetInnerHTML={{
             __html: `
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
 
-              var hasConsent = false;
-              try { hasConsent = localStorage.getItem('cookieConsent') === 'accepted'; } catch(e) {}
+              var stored = null;
+              try { stored = localStorage.getItem('cookieConsent'); } catch(e) {}
 
-              gtag('consent', 'default', {
-                'analytics_storage': hasConsent ? 'granted' : 'denied',
-                'ad_storage': hasConsent ? 'granted' : 'denied',
-                'ad_user_data': hasConsent ? 'granted' : 'denied',
-                'ad_personalization': hasConsent ? 'granted' : 'denied',
-              });
+              if (stored === 'accepted') {
+                gtag('consent', 'default', {
+                  ad_storage: 'granted',
+                  analytics_storage: 'granted',
+                  ad_user_data: 'granted',
+                  ad_personalization: 'granted'
+                });
+              } else if (stored === 'declined') {
+                gtag('consent', 'default', {
+                  ad_storage: 'denied',
+                  analytics_storage: 'denied',
+                  ad_user_data: 'denied',
+                  ad_personalization: 'denied'
+                });
+              } else {
+                gtag('consent', 'default', {
+                  ad_storage: 'denied',
+                  analytics_storage: 'denied',
+                  ad_user_data: 'denied',
+                  ad_personalization: 'denied',
+                  region: ${JSON.stringify(CONSENT_REQUIRED_REGIONS)}
+                });
+                gtag('consent', 'default', {
+                  ad_storage: 'granted',
+                  analytics_storage: 'granted',
+                  ad_user_data: 'granted',
+                  ad_personalization: 'granted'
+                });
+              }
+
+              gtag('set', 'url_passthrough', true);
+              gtag('set', 'ads_data_redaction', true);
             `,
           }}
         />
@@ -59,7 +92,7 @@ export default function RootLayout({
             {children}
             <Toaster />
 
-            <ConsentBanner />
+            <ConsentBanner requiresConsent={requiresConsent} />
           </TRPCReactProvider>
         </Suspense>
       </body>

--- a/src/components/shared/ConsentBanner.tsx
+++ b/src/components/shared/ConsentBanner.tsx
@@ -19,17 +19,22 @@ function updateConsent(granted: boolean) {
   });
 }
 
-export default function ConsentBanner() {
+interface ConsentBannerProps {
+  requiresConsent: boolean;
+}
+
+export default function ConsentBanner({ requiresConsent }: ConsentBannerProps) {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    // Returning users already have consent set in the head script (layout.tsx).
-    // Only show the banner if the user hasn't made a choice yet.
+    // Banner only renders in regions that legally require explicit opt-in.
+    // Elsewhere, defaults are 'granted' via the head script (layout.tsx).
+    if (!requiresConsent) return;
     const consent = localStorage.getItem("cookieConsent");
     if (!consent) {
       setIsVisible(true);
     }
-  }, []);
+  }, [requiresConsent]);
 
   const handleAccept = () => {
     localStorage.setItem("cookieConsent", "accepted");

--- a/src/lib/consent-region.ts
+++ b/src/lib/consent-region.ts
@@ -1,0 +1,49 @@
+// ISO 3166-1 alpha-2 codes for regions where explicit opt-in consent is
+// required before storing analytics/advertising cookies (GDPR, UK GDPR, nFADP).
+export const CONSENT_REQUIRED_REGIONS = [
+  // EU
+  "AT",
+  "BE",
+  "BG",
+  "HR",
+  "CY",
+  "CZ",
+  "DK",
+  "EE",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HU",
+  "IE",
+  "IT",
+  "LV",
+  "LT",
+  "LU",
+  "MT",
+  "NL",
+  "PL",
+  "PT",
+  "RO",
+  "SK",
+  "SI",
+  "ES",
+  "SE",
+  // EEA (non-EU)
+  "IS",
+  "LI",
+  "NO",
+  // UK
+  "GB",
+  // Switzerland
+  "CH",
+] as const;
+
+export function isConsentRequiredCountry(
+  country: string | null | undefined,
+): boolean {
+  if (!country) return true; // safe default when geo is unknown
+  return (CONSENT_REQUIRED_REGIONS as readonly string[]).includes(
+    country.toUpperCase(),
+  );
+}


### PR DESCRIPTION
## Summary
- Restores analytics tracking for non-EU users. PR #69 set a global denied-by-default consent state, which dropped active users ~80% (visible in GA4 from late March onward) because most visitors never interact with the banner.
- Switches to Google's canonical region-targeted Consent Mode v2 pattern: EU/EEA/UK/CH default to `denied`, everywhere else defaults to `granted`. Geo lookup is handled by Google's tag platform via the `region` key on `gtag('consent', 'default', ...)`.
- Banner UI is now gated by server-side geo (`x-vercel-ip-country`), so non-EU users never see it. Defaults to "consent required" when the header is missing, so non-Vercel hosts and unknown geos stay on the safe side.
- Explicit `accepted` / `declined` choices in localStorage always override the region default and persist across visits, so returning users keep their decision.
- Adds `url_passthrough: true` and `ads_data_redaction: true` so denied EU users still send cookieless pings → GA4 modeled traffic, instead of zero data.

## Files
- `src/lib/consent-region.ts` (new) — list of 32 ISO codes (EU + EEA + UK + CH) and a `isConsentRequiredCountry` helper.
- `src/app/layout.tsx` — async, reads `x-vercel-ip-country`, rewrites the head consent script with the region-aware pattern, passes `requiresConsent` to the banner.
- `src/components/shared/ConsentBanner.tsx` — accepts `requiresConsent` prop and bails out early when false.

## Test plan
- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm lint` clean — no new warnings (verified locally)
- [ ] `pnpm test` passes — 26/26 (verified locally)
- [ ] After deploy, verify in GA4 DebugView that a non-EU visitor (US) loads with `analytics_storage=granted` and a page_view fires immediately
- [ ] Verify an EU visitor (e.g. via VPN to DE/FR/GB) loads with `analytics_storage=denied`, sees the banner, and that consent updates to granted on accept
- [ ] Verify localStorage `cookieConsent=accepted` set on a previous visit causes the banner to stay hidden and tracking to fire on first paint
- [ ] Confirm GA4 Active Users metric recovers toward pre-March 29 baseline over the next several days