### PR TITLE
fix: move consent geo lookup behind Suspense to unblock prerender

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import "~/styles/globals.css";
 import { Suspense } from "react";
-import { headers } from "next/headers";
 import { Inter } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "~/components/ui/toaster";
 import { defaultMetadata } from "~/config/metadata";
 import { GoogleTagManager } from "@next/third-parties/google";
 
-import ConsentBanner from "~/components/shared/ConsentBanner";
-import {
-  CONSENT_REQUIRED_REGIONS,
-  isConsentRequiredCountry,
-} from "~/lib/consent-region";
+import ConsentBannerGeo from "~/components/shared/ConsentBannerGeo";
+import { CONSENT_REQUIRED_REGIONS } from "~/lib/consent-region";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -20,12 +16,10 @@ const inter = Inter({
 
 export const metadata = defaultMetadata;
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const gtmId = process.env.NEXT_PUBLIC_GA_ID!;
-  const country = (await headers()).get("x-vercel-ip-country");
-  const requiresConsent = isConsentRequiredCountry(country);
 
   return (
     <html lang="en" className={`${inter.variable}`}>
@@ -92,7 +86,9 @@ export default async function RootLayout({
             {children}
             <Toaster />
 
-            <ConsentBanner requiresConsent={requiresConsent} />
+            <Suspense>
+              <ConsentBannerGeo />
+            </Suspense>
           </TRPCReactProvider>
         </Suspense>
       </body>

--- a/src/components/shared/ConsentBannerGeo.tsx
+++ b/src/components/shared/ConsentBannerGeo.tsx
@@ -1,0 +1,9 @@
+import { headers } from "next/headers";
+import { isConsentRequiredCountry } from "~/lib/consent-region";
+import ConsentBanner from "./ConsentBanner";
+
+export default async function ConsentBannerGeo() {
+  const country = (await headers()).get("x-vercel-ip-country");
+  const requiresConsent = isConsentRequiredCountry(country);
+  return <ConsentBanner requiresConsent={requiresConsent} />;
+}


### PR DESCRIPTION
## Summary
- Hotfix for the failing Vercel deploy after #82. Build was breaking on `/_not-found` (and other prerendered routes) with `Uncached data was accessed outside of <Suspense>`.
- Root cause: `await headers()` at the top of `RootLayout` made the layout itself dynamic. Under `cacheComponents: true` (next.config.js) every static prerender saw uncached data leaking outside a Suspense boundary and refused to render.
- Layout is back to sync. The `gtag('consent', 'default', ...)` head script keeps the region-targeted consent pattern using the static `CONSENT_REQUIRED_REGIONS` constant, so no dynamic data is needed in the static shell.
- Geo-based banner gating moves into a new server component `ConsentBannerGeo` that reads `x-vercel-ip-country` and renders the existing client `ConsentBanner` with the resolved `requiresConsent` prop. It's wrapped in its own `<Suspense>` inside the body, so the banner streams in dynamically while the rest of the tree prerenders cleanly.

## Files
- `src/app/layout.tsx` — sync again; uses `<Suspense><ConsentBannerGeo /></Suspense>` instead of computing `requiresConsent` at the top.
- `src/components/shared/ConsentBannerGeo.tsx` (new) — async server component that reads headers and renders `ConsentBanner`.

## Test plan
- [x] `pnpm build` passes locally — 36/36 pages generated, prerendered routes show `◐` (Partial Prerender)
- [x] `pnpm test` — 26/26 passing
- [ ] Vercel deploy succeeds on this branch
- [ ] After merge, verify in GA4 DebugView that a US visitor still gets `analytics_storage=granted` and an EU/UK/CH visitor still sees the banner with `denied` default

## Notes
- `pnpm typecheck` and `pnpm lint` show pre-existing errors on `main` in `src/components/ui/select.tsx` (refers to `@radix-ui/react-select`, which is no longer installed). Confirmed not caused by this PR. The `chore/fallow-cleanup` branch already removes that file.