### PR TITLE
fix: resolve Safari HierarchyRequestError blank page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import "~/styles/globals.css";
 import { Suspense } from "react";
+import Script from "next/script";
 import { Inter } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "~/components/ui/toaster";
@@ -23,17 +24,10 @@ export default function RootLayout({
 
   return (
     <html lang="en" className={`${inter.variable}`}>
-      <head>
-        <meta
-          property="og:image"
-          content="https://res.cloudinary.com/wedgietracker/image/upload/v1736700345/assets/social-wedgietracker_bibnbu.jpg"
-        />
-        <meta
-          property="twitter:image"
-          content="https://res.cloudinary.com/wedgietracker/image/upload/v1736700345/assets/social-wedgietracker_bibnbu.jpg"
-        />
-        {/* Consent Mode v2 — region-targeted defaults, applied before GTM loads */}
-        <script
+      <body className="bg-darkpurple">
+        <Script
+          id="gtm-consent-defaults"
+          strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: `
               window.dataLayer = window.dataLayer || [];
@@ -77,8 +71,6 @@ export default function RootLayout({
             `,
           }}
         />
-      </head>
-      <body className="bg-darkpurple">
         <GoogleTagManager gtmId={gtmId} />
 
         <Suspense>

--- a/src/config/metadata.ts
+++ b/src/config/metadata.ts
@@ -5,6 +5,8 @@ const APP_DESCRIPTION =
   "NBA original WedgieTracker. We count how many times a basketball gets stuck between the rim and the backboard. NoDunks Inspired.";
 const APP_URL =
   process.env.NEXT_PUBLIC_APP_URL ?? "https://www.wedgietracker.com";
+const DEFAULT_SOCIAL_IMAGE =
+  "https://res.cloudinary.com/wedgietracker/image/upload/v1736700345/assets/social-wedgietracker_bibnbu.jpg";
 
 export const defaultMetadata: Metadata = {
   applicationName: APP_NAME,
@@ -31,6 +33,7 @@ export const defaultMetadata: Metadata = {
     },
     description: APP_DESCRIPTION,
     url: APP_URL,
+    images: [{ url: DEFAULT_SOCIAL_IMAGE }],
   },
   twitter: {
     card: "summary",
@@ -39,6 +42,7 @@ export const defaultMetadata: Metadata = {
       template: `%s | ${APP_NAME}`,
     },
     description: APP_DESCRIPTION,
+    images: [DEFAULT_SOCIAL_IMAGE],
   },
   icons: [
     { rel: "icon", url: "/favicon.ico" },
@@ -65,13 +69,13 @@ export function generateMetadata({
       ...defaultMetadata.openGraph,
       title: title,
       description: description,
-      images: image ? [{ url: image }] : undefined,
+      images: image ? [{ url: image }] : defaultMetadata.openGraph?.images,
     },
     twitter: {
       ...defaultMetadata.twitter,
       title: title,
       description: description,
-      images: image ? [image] : undefined,
+      images: image ? [image] : defaultMetadata.twitter?.images,
     },
     robots: {
       index: !noIndex,


### PR DESCRIPTION
## Summary
- Safari rendered a blank page with `HierarchyRequestError: The operation would yield an incorrect node tree.` because the root layout combined a manual `<head>` element + exported `metadata` + an inline `<script dangerouslySetInnerHTML>` in that head. During hydration, Next/React reorder and hoist head children; Safari's stricter DOM hierarchy validation rejects the resulting tree (Chrome silently accepts it).
- Drop the manual `<head>` so the metadata API owns head injection, and move the GA4 Consent Mode v2 defaults to `next/script` with `strategy="beforeInteractive"` — the canonical Next pattern for cookie consent managers; runs before GTM loads.
- Move the static og:image / twitter:image into `defaultMetadata`. `generateMetadata` now falls back to the defaults when no per-page image is supplied, so social previews are unchanged.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] Load the site in Safari — page renders, no `HierarchyRequestError` in the console
- [ ] Load in Chrome — no regression
- [ ] In an EU region (or with `localStorage.cookieConsent` cleared), confirm the consent banner shows and Accept/Decline still toggles GTM consent
- [ ] Outside the EU, confirm the banner does not show and analytics still fire
- [ ] View source / og scrape on `/`, `/standings`, `/all-wedgies` — `og:image` and `twitter:image` are present