### PR TITLE
fix: render consent script as plain <script>, not next/script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import "~/styles/globals.css";
 import { Suspense } from "react";
-import Script from "next/script";
 import { Inter } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "~/components/ui/toaster";
@@ -17,6 +16,47 @@ const inter = Inter({
 
 export const metadata = defaultMetadata;
 
+const consentDefaultsScript = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+
+  var stored = null;
+  try { stored = localStorage.getItem('cookieConsent'); } catch(e) {}
+
+  if (stored === 'accepted') {
+    gtag('consent', 'default', {
+      ad_storage: 'granted',
+      analytics_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted'
+    });
+  } else if (stored === 'declined') {
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied'
+    });
+  } else {
+    gtag('consent', 'default', {
+      ad_storage: 'denied',
+      analytics_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+      region: ${JSON.stringify(CONSENT_REQUIRED_REGIONS)}
+    });
+    gtag('consent', 'default', {
+      ad_storage: 'granted',
+      analytics_storage: 'granted',
+      ad_user_data: 'granted',
+      ad_personalization: 'granted'
+    });
+  }
+
+  gtag('set', 'url_passthrough', true);
+  gtag('set', 'ads_data_redaction', true);
+`;
+
 export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
@@ -25,52 +65,16 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable}`}>
       <body className="bg-darkpurple">
-        <Script
-          id="gtm-consent-defaults"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-
-              var stored = null;
-              try { stored = localStorage.getItem('cookieConsent'); } catch(e) {}
-
-              if (stored === 'accepted') {
-                gtag('consent', 'default', {
-                  ad_storage: 'granted',
-                  analytics_storage: 'granted',
-                  ad_user_data: 'granted',
-                  ad_personalization: 'granted'
-                });
-              } else if (stored === 'declined') {
-                gtag('consent', 'default', {
-                  ad_storage: 'denied',
-                  analytics_storage: 'denied',
-                  ad_user_data: 'denied',
-                  ad_personalization: 'denied'
-                });
-              } else {
-                gtag('consent', 'default', {
-                  ad_storage: 'denied',
-                  analytics_storage: 'denied',
-                  ad_user_data: 'denied',
-                  ad_personalization: 'denied',
-                  region: ${JSON.stringify(CONSENT_REQUIRED_REGIONS)}
-                });
-                gtag('consent', 'default', {
-                  ad_storage: 'granted',
-                  analytics_storage: 'granted',
-                  ad_user_data: 'granted',
-                  ad_personalization: 'granted'
-                });
-              }
-
-              gtag('set', 'url_passthrough', true);
-              gtag('set', 'ads_data_redaction', true);
-            `,
-          }}
-        />
+        {/*
+         * GA4 Consent Mode v2 defaults — must execute before GTM loads.
+         * Rendered as a plain React <script> (not next/script) because
+         * `strategy="beforeInteractive"` with inline dangerouslySetInnerHTML
+         * triggers Safari's HierarchyRequestError under Next 16's streaming
+         * metadata + cacheComponents (vercel/next.js#43383).
+         * React 19 does not hoist inline scripts, so this executes during
+         * HTML parse — before the afterInteractive GTM script.
+         */}
+        <script dangerouslySetInnerHTML={{ __html: consentDefaultsScript }} />
         <GoogleTagManager gtmId={gtmId} />
 
         <Suspense>


### PR DESCRIPTION
## Summary
- PR #85 moved the GA4 Consent Mode v2 defaults to `<Script id strategy="beforeInteractive" dangerouslySetInnerHTML>`. Safari kept rendering a blank page with `HierarchyRequestError: The operation would yield an incorrect node tree.` — the longstanding [vercel/next.js#43383](https://github.com/vercel/next.js/issues/43383) (`<Script beforeInteractive>` injects inline scripts via the runtime `__next_s` queue and crashes hydration), made reliably reproducible on Safari by Next 16's streaming metadata + `cacheComponents`.
- React 19 does not hoist inline `<script>` tags (only `src + async`, see [react.dev](https://react.dev/reference/react-dom/components/script)), so a plain React `<script dangerouslySetInnerHTML>` in `<body>` is emitted by SSR and executes during HTML parse — before GTM's `afterInteractive` script loads. The consent-before-GTM ordering is preserved without going through the broken `beforeInteractive` path.

## Background
HAR captured after PR #85 deployed showed the streaming HTML still triggered the error in Safari while the `__next_s.push([0, {... "id":"gtm-consent-defaults"}])` payload was being processed. Reverting just the script-injection mechanism (not the metadata changes from PR #85) is enough.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] Load `/` in Safari — page renders, no `HierarchyRequestError` in the console
- [ ] Load in Chrome/Firefox — no regression
- [ ] In an EU region (or with `localStorage.cookieConsent` cleared), confirm the consent banner shows and Accept/Decline still toggles GTM consent
- [ ] Outside the EU, confirm the banner does not show and analytics still fire (`page_view`, etc.)
- [ ] Confirm `gtag('consent', 'default', ...)` is in `dataLayer` *before* GTM initialization (DevTools → Network → first `dataLayer.push` order)