### PR TITLE
fix: inline GTM bootstrap and add Suspense fallback

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,6 @@ import { Inter } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "~/components/ui/toaster";
 import { defaultMetadata } from "~/config/metadata";
-import { GoogleTagManager } from "@next/third-parties/google";
 
 import ConsentBannerGeo from "~/components/shared/ConsentBannerGeo";
 import { CONSENT_REQUIRED_REGIONS } from "~/lib/consent-region";
@@ -16,7 +15,14 @@ const inter = Inter({
 
 export const metadata = defaultMetadata;
 
-const consentDefaultsScript = `
+/**
+ * GA4 Consent Mode v2 defaults + GTM bootstrap, inlined as one plain
+ * <script>. Replaces @next/third-parties' <GoogleTagManager>, which is a
+ * "use client" wrapper around <Script> and adds an extra client-component
+ * boundary at the top of <body>. Folding the dataLayer init + script
+ * loader into a single plain SSR script avoids that boundary entirely.
+ */
+const buildBootstrapScript = (gtmId: string) => `
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
 
@@ -55,6 +61,16 @@ const consentDefaultsScript = `
 
   gtag('set', 'url_passthrough', true);
   gtag('set', 'ads_data_redaction', true);
+
+  // GTM bootstrap (inlined from @next/third-parties' _next-gtm-init):
+  window.dataLayer.push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+  (function() {
+    var f = document.getElementsByTagName('script')[0];
+    var j = document.createElement('script');
+    j.async = true;
+    j.src = 'https://www.googletagmanager.com/gtm.js?id=${gtmId}';
+    f.parentNode.insertBefore(j, f);
+  })();
 `;
 
 export default function RootLayout({
@@ -65,24 +81,16 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${inter.variable}`}>
       <body className="bg-darkpurple">
-        {/*
-         * GA4 Consent Mode v2 defaults — must execute before GTM loads.
-         * Rendered as a plain React <script> (not next/script) because
-         * `strategy="beforeInteractive"` with inline dangerouslySetInnerHTML
-         * triggers Safari's HierarchyRequestError under Next 16's streaming
-         * metadata + cacheComponents (vercel/next.js#43383).
-         * React 19 does not hoist inline scripts, so this executes during
-         * HTML parse — before the afterInteractive GTM script.
-         */}
-        <script dangerouslySetInnerHTML={{ __html: consentDefaultsScript }} />
-        <GoogleTagManager gtmId={gtmId} />
+        <script
+          dangerouslySetInnerHTML={{ __html: buildBootstrapScript(gtmId) }}
+        />
 
-        <Suspense>
+        <Suspense fallback={<div className="bg-darkpurple min-h-screen" />}>
           <TRPCReactProvider>
             {children}
             <Toaster />
 
-            <Suspense>
+            <Suspense fallback={null}>
               <ConsentBannerGeo />
             </Suspense>
           </TRPCReactProvider>


### PR DESCRIPTION
## Context
Safari console reproducibly throws:

```
HierarchyRequestError: The operation would yield an incorrect node tree.
  insertBefore — :40:33564
  $RV          — :40:33564
  requestAnimationFrame
  $RC          — :41:186
  Global Code  — :41:325
```

`$RC` and `$RV` are React 19's out-of-order Suspense reveal helpers. `B:4` is the outer `<Suspense>` in `app/layout.tsx`; revealing it makes Safari trip on `insertBefore`. Tracks [vercel/next.js#52444](https://github.com/vercel/next.js/issues/52444) / [#76272](https://github.com/vercel/next.js/issues/76272).

Removing the outer Suspense breaks builds — `cacheComponents: true` requires it to absorb page-level awaits in `/blog/[slug]` and `/store/success`. So this PR shrinks the streaming surface and softens the failure mode instead.

## Changes
- **Inline the GTM bootstrap.** `@next/third-parties`' `<GoogleTagManager>` is a `"use client"` wrapper around two `<Script>` components — that's an extra client-component boundary at the top of `<body>`. Folding the `dataLayer` init and script loader into a single plain SSR `<script>` removes that boundary; the inline tag executes during HTML parse, before `$RC` ever runs.
- **Add a Suspense fallback.** A `min-h-screen` `bg-darkpurple` div means that even if Safari's reveal still fails, the user sees a colored screen instead of a fully blank page.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] Safari: load `/`, hard reload, confirm page renders (or at least the dark fallback is visible if reveal still fails)
- [ ] Chrome/Firefox: no regression
- [ ] Confirm GTM still loads (`gtm.js` request fires) and `dataLayer` contains the `gtm.start` event before any consent default
- [ ] In an EU region (or with `localStorage.cookieConsent` cleared), confirm the consent banner shows and Accept/Decline still toggles GTM consent
- [ ] Outside the EU, confirm analytics still fire (`page_view`)

## Follow-up
If Safari is still blank after this lands, the root fix is to refactor every page that does top-level uncached `await` (currently `/blog/[slug]`, `/store/success`, possibly more) to wrap its data fetching in its own `<Suspense>` and then drop the outer layout `<Suspense>` entirely. That's the canonical Next 16 / cacheComponents pattern but is invasive — leaving it as a follow-up depending on whether this PR is enough.