### PR TITLE
fix: drop layout outer Suspense, wrap pages individually

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { PageLayout } from "~/components/layout/PageLayout";
 import { BlogPost } from "~/components/blog/BlogPost";
@@ -5,6 +6,7 @@ import { api } from "~/trpc/server";
 import Link from "next/link";
 import { Button } from "~/components/ui/button";
 import { ArrowLeftIcon } from "lucide-react";
+import { Loader } from "~/components/shared/Loader";
 
 interface Props {
   params: Promise<{
@@ -12,14 +14,7 @@ interface Props {
   }>;
 }
 
-export default async function BlogPostPage({ params }: Props) {
-  const resolvedParams = await params;
-  const post = await api.blog.getBySlug({ slug: resolvedParams.slug });
-
-  if (!post) {
-    notFound();
-  }
-
+export default function BlogPostPage({ params }: Props) {
   return (
     <PageLayout>
       <div className="mx-auto max-w-4xl px-4 py-8 md:px-8">
@@ -32,8 +27,27 @@ export default async function BlogPostPage({ params }: Props) {
             Back to Blog
           </Button>
         </Link>
-        <BlogPost post={post} />
+        <Suspense
+          fallback={
+            <div className="flex min-h-[60svh] items-center justify-center">
+              <Loader />
+            </div>
+          }
+        >
+          <BlogPostBody params={params} />
+        </Suspense>
       </div>
     </PageLayout>
   );
+}
+
+async function BlogPostBody({ params }: Props) {
+  const resolvedParams = await params;
+  const post = await api.blog.getBySlug({ slug: resolvedParams.slug });
+
+  if (!post) {
+    notFound();
+  }
+
+  return <BlogPost post={post} />;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -85,16 +85,14 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: buildBootstrapScript(gtmId) }}
         />
 
-        <Suspense fallback={<div className="bg-darkpurple min-h-screen" />}>
-          <TRPCReactProvider>
-            {children}
-            <Toaster />
+        <TRPCReactProvider>
+          {children}
+          <Toaster />
 
-            <Suspense fallback={null}>
-              <ConsentBannerGeo />
-            </Suspense>
-          </TRPCReactProvider>
-        </Suspense>
+          <Suspense fallback={null}>
+            <ConsentBannerGeo />
+          </Suspense>
+        </TRPCReactProvider>
       </body>
     </html>
   );

--- a/src/app/store/success/page.tsx
+++ b/src/app/store/success/page.tsx
@@ -1,13 +1,35 @@
+import { Suspense } from "react";
 import { connection } from "next/server";
 import Link from "next/link";
 import { PageLayout } from "~/components/layout/PageLayout";
+import { Loader } from "~/components/shared/Loader";
 
 interface SearchParams {
   session_id?: string;
   coffee?: string;
 }
 
-export default async function SuccessPage({
+export default function SuccessPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  return (
+    <PageLayout showCircleMenu={false}>
+      <Suspense
+        fallback={
+          <div className="flex flex-1 items-center justify-center px-4">
+            <Loader />
+          </div>
+        }
+      >
+        <SuccessBody searchParams={searchParams} />
+      </Suspense>
+    </PageLayout>
+  );
+}
+
+async function SuccessBody({
   searchParams,
 }: {
   searchParams: Promise<SearchParams>;
@@ -17,49 +39,47 @@ export default async function SuccessPage({
   const sessionId = params.session_id;
   const coffee = params.coffee;
   return (
-    <PageLayout showCircleMenu={false}>
-      <div className="flex flex-1 items-center justify-center px-4">
-        <div className="max-w-md text-center">
-          <h1 className="text-yellow mb-4 text-4xl font-bold">Thank You!</h1>
-          {coffee === "true" ? (
-            <p className="mb-4 text-xl text-white">
-              Your coffee donation has been confirmed.
-            </p>
-          ) : (
-            <p className="mb-4 text-xl text-white">
-              Your order has been confirmed.
-            </p>
-          )}
+    <div className="flex flex-1 items-center justify-center px-4">
+      <div className="max-w-md text-center">
+        <h1 className="text-yellow mb-4 text-4xl font-bold">Thank You!</h1>
+        {coffee === "true" ? (
+          <p className="mb-4 text-xl text-white">
+            Your coffee donation has been confirmed.
+          </p>
+        ) : (
+          <p className="mb-4 text-xl text-white">
+            Your order has been confirmed.
+          </p>
+        )}
 
-          {sessionId && coffee !== "true" && (
-            <div className="bg-darkpurple-light mb-6 rounded-lg p-4">
-              <p className="mb-2 text-sm text-white/60">Order ID</p>
-              <p className="font-mono text-sm break-all text-white">
-                {sessionId}
-              </p>
-            </div>
-          )}
-
-          {coffee === "true" ? (
-            <p className="mb-8 text-sm text-white/80">
-              We&apos;ve sent you a confirmation email. Please check your inbox
-              (and spam/junk folder) for the donation details.
+        {sessionId && coffee !== "true" && (
+          <div className="bg-darkpurple-light mb-6 rounded-lg p-4">
+            <p className="mb-2 text-sm text-white/60">Order ID</p>
+            <p className="font-mono text-sm break-all text-white">
+              {sessionId}
             </p>
-          ) : (
-            <p className="mb-8 text-sm text-white/80">
-              We&apos;ve sent you a confirmation email. Please check your inbox
-              (and spam/junk folder) for the order details.
-            </p>
-          )}
+          </div>
+        )}
 
-          <Link
-            href="/store"
-            className="bg-pink hover:bg-pink/80 rounded-lg px-8 py-4 font-bold text-white transition-all"
-          >
-            Return to Store
-          </Link>
-        </div>
+        {coffee === "true" ? (
+          <p className="mb-8 text-sm text-white/80">
+            We&apos;ve sent you a confirmation email. Please check your inbox
+            (and spam/junk folder) for the donation details.
+          </p>
+        ) : (
+          <p className="mb-8 text-sm text-white/80">
+            We&apos;ve sent you a confirmation email. Please check your inbox
+            (and spam/junk folder) for the order details.
+          </p>
+        )}
+
+        <Link
+          href="/store"
+          className="bg-pink hover:bg-pink/80 rounded-lg px-8 py-4 font-bold text-white transition-all"
+        >
+          Return to Store
+        </Link>
       </div>
-    </PageLayout>
+    </div>
   );
 }


### PR DESCRIPTION
## Context
Safari kept blanking with `HierarchyRequestError` because React 19 was revealing the root layout's outer `<Suspense>` (boundary `B:4`) out-of-order, and `$RV`'s `insertBefore` tripped WebKit ([vercel/next.js#52444](https://github.com/vercel/next.js/issues/52444)). PRs #85, #86, #87 softened the failure (added a visible fallback, removed client-component boundaries) but **none of them stopped `B:4` from streaming**.

## Why the outer Suspense existed
`cacheComponents: true` requires every uncached data access to live inside `<Suspense>`. Two pages were doing top-level `await`s without their own boundary, and the layout's outer Suspense was absorbing them:
- `/blog/[slug]` — `await api.blog.getBySlug({ slug })`
- `/store/success` — `await connection()` + `await searchParams`

## Fix
Wrap each page's data-loading body in its own `<Suspense>` (the canonical Next 16 / cacheComponents pattern) and drop the layout's outer Suspense. The inner Suspense around `ConsentBannerGeo` stays — that's the only piece in the layout itself that awaits dynamic data.

## Verification
SSR HTML for `/` before (after PR #87, broken on Safari):
```html
<body>
  <div hidden=""><!--$--><!--/$--></div>
  <script>...consent + GTM bootstrap...</script>
  <!--$?--><template id="B:4"></template><div class="bg-darkpurple min-h-screen"></div><!--/$-->  ← B:4 reveal trips Safari
  ...
  <div hidden id="S:4"><!--&-->...page content...</div>
</body>
```

After this PR:
```html
<body>
  <div hidden=""><!--$--><!--/$--></div>
  <script>...consent + GTM bootstrap...</script>
  <!--&--><div class="bg-darkpurple flex min-h-screen flex-col">...page content rendered inline...</div>
  ...
</body>
```

`B:4` is gone. Page content streams inline. Only the page-internal `B:0`–`B:3` Suspenses still reveal out-of-order, and they're scoped to small page sub-trees, not the entire body.

Locally:
- [x] `pnpm typecheck`
- [x] `pnpm build` (all 35 routes generate)
- [x] `curl /` confirms no `B:4` in SSR HTML

## Test plan
- [ ] Safari (the actual reason this PR exists): hard reload `/`, `/blog/<slug>`, `/store/success` — page renders, no `HierarchyRequestError`
- [ ] Chrome/Firefox: no regression
- [ ] `/blog/<slug>`: loader shows briefly, then post body
- [ ] `/store/success?session_id=...`: loader shows briefly, then thank-you content with the session id
- [ ] In an EU region (or with `localStorage.cookieConsent` cleared), confirm consent banner shows and Accept/Decline still toggles GTM consent
- [ ] Outside EU: analytics fire (`page_view`)

## Follow-up
Other admin pages (`/admin/wedgies`, `/admin/wedgies/[id]`, `/stats-for-nerds`) also do top-level uncached awaits. They didn't fail the build because they're behind the route guard, but they would have the same Safari issue if hit directly. Wrapping them is a clean follow-up but not required for this fix.