### PR TITLE
chore: assign dependabot PRs to gek0z

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - "gek0z"
+    assignees:
+      - "gek0z"
     groups:
       minor-and-patch:
         update-types:
@@ -23,6 +25,8 @@ updates:
     schedule:
       interval: "monthly"
     reviewers:
+      - "gek0z"
+    assignees:
       - "gek0z"
     groups:
       all-actions:


### PR DESCRIPTION
## Summary
- Add `assignees: ["gek0z"]` to both npm and github-actions Dependabot update configs so new Dependabot PRs are auto-assigned (in addition to the existing reviewer setting).

## Test plan
- [ ] Wait for next Dependabot run (or trigger via Insights → Dependency graph → Dependabot) and confirm new PRs are both assigned to and requesting review from gek0z.