### PR TITLE
perf: trim Fluid CPU on hot data paths

### DIFF
--- a/src/app/api/external/route.ts
+++ b/src/app/api/external/route.ts
@@ -60,8 +60,24 @@ async function syncIncomingGames(newGames: NewGameInput[]) {
     console.log(
       `Updating live status for ${existingGamesToUpdate.length} existing games`,
     );
-    for (const g of existingGamesToUpdate) {
-      await db.update(game).set({ live: g.live }).where(eq(game.id, g.id));
+    const liveIds = existingGamesToUpdate
+      .filter((g) => g.live)
+      .map((g) => g.id);
+    const notLiveIds = existingGamesToUpdate
+      .filter((g) => !g.live)
+      .map((g) => g.id);
+
+    if (liveIds.length > 0) {
+      await db
+        .update(game)
+        .set({ live: true })
+        .where(inArray(game.id, liveIds));
+    }
+    if (notLiveIds.length > 0) {
+      await db
+        .update(game)
+        .set({ live: false })
+        .where(inArray(game.id, notLiveIds));
     }
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,10 +64,9 @@ async function WedgieListWrapper() {
 
 async function StandingsWrapper() {
   const standings = await api.wedgie.getTopStandings();
-  const stats = await api.wedgie.getStats();
 
   // Hide standings content when there are 0 wedgies this season
-  if (stats.currentSeasonWedgies === 0) {
+  if (!standings.hasWedgiesThisSeason) {
     return (
       <div className="flex w-full max-w-2xl flex-col items-center justify-center">
         <Link

--- a/src/server/api/routers/wedgie.ts
+++ b/src/server/api/routers/wedgie.ts
@@ -120,7 +120,7 @@ async function getWedgiesWithTypes(wedgieRows: { id: number }[]) {
 async function getCachedAll() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const wedgies = await db
     .select()
@@ -133,7 +133,7 @@ async function getCachedAll() {
 async function getCachedBySeason(seasonName: string) {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const wedgies = await db
     .select()
@@ -147,7 +147,7 @@ async function getCachedBySeason(seasonName: string) {
 async function getCachedLatest() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   return db.query.wedgie.findFirst({
     orderBy: desc(wedgie.createdAt),
@@ -157,7 +157,7 @@ async function getCachedLatest() {
 async function getCachedLatestWedgies() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const wedgies = await db
     .select()
@@ -171,7 +171,7 @@ async function getCachedLatestWedgies() {
 async function getCachedStats() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 60 });
+  cacheLife({ revalidate: 3600 });
 
   const globalSettings = await db.query.global.findFirst({
     where: eq(global.id, 1),
@@ -229,7 +229,7 @@ async function getCachedStats() {
 async function getCachedTopStandings() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const currentSeasonGlobal = await db.query.global.findFirst({
     where: eq(global.id, 1),
@@ -260,6 +260,7 @@ async function getCachedTopStandings() {
       count: p.count,
     })),
     teams: buildTeamStandings(wedgies, { limit: 5 }),
+    hasWedgiesThisSeason: wedgies.length > 0,
   };
 }
 
@@ -269,7 +270,7 @@ async function getCachedSeasonStandings(
 ) {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const whereClause = seasonFilter
     ? eq(wedgie.seasonName, seasonFilter)
@@ -304,7 +305,7 @@ async function getCachedSeasonStandings(
 async function getCachedNerdStats() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 300 });
+  cacheLife({ revalidate: 3600 });
 
   const globalRow = await db.query.global.findFirst({
     where: eq(global.id, 1),
@@ -433,10 +434,87 @@ async function getCachedNerdStats() {
   };
 }
 
+async function getCachedByPlayer(playerName: string) {
+  "use cache";
+  cacheTag(CACHE_TAGS.WEDGIE_DATA);
+  cacheLife({ revalidate: 3600 });
+
+  return db.select().from(wedgie).where(eq(wedgie.playerName, playerName));
+}
+
+async function getCachedByType(typeName: string) {
+  "use cache";
+  cacheTag(CACHE_TAGS.WEDGIE_DATA);
+  cacheLife({ revalidate: 3600 });
+
+  const rows = await db
+    .select({ wedgieId: wedgieToType.wedgieId })
+    .from(wedgieToType)
+    .innerJoin(typeTable, eq(wedgieToType.typeId, typeTable.id))
+    .where(eq(typeTable.name, typeName));
+
+  if (rows.length === 0) return [];
+
+  const wedgieIds = rows.map((r) => r.wedgieId);
+  return db.select().from(wedgie).where(inArray(wedgie.id, wedgieIds));
+}
+
+async function getCachedSelfHostedVideos() {
+  "use cache";
+  cacheTag(CACHE_TAGS.WEDGIE_DATA);
+  cacheLife({ revalidate: 3600 });
+
+  const wedgies = await db
+    .select({
+      id: wedgie.id,
+      wedgieDate: wedgie.wedgieDate,
+      videoUrl: wedgie.videoUrl,
+      playerName: wedgie.playerName,
+      teamName: wedgie.teamName,
+      teamAgainstName: wedgie.teamAgainstName,
+      number: wedgie.number,
+      seasonName: wedgie.seasonName,
+    })
+    .from(wedgie)
+    .where(
+      and(
+        sql`json_extract(${wedgie.videoUrl}, '$.selfHosted') IS NOT NULL`,
+        ne(wedgie.seasonName, "GEMS"),
+      ),
+    );
+
+  return wedgies
+    .filter((w) => !(w.videoUrl as VideoUrls)?.youtube)
+    .sort(
+      (a, b) =>
+        new Date(b.wedgieDate).getTime() - new Date(a.wedgieDate).getTime(),
+    );
+}
+
+async function getCachedCloudinaryWedgies() {
+  "use cache";
+  cacheTag(CACHE_TAGS.WEDGIE_DATA);
+  cacheLife({ revalidate: 3600 });
+
+  return db
+    .select({
+      id: wedgie.id,
+      playerName: wedgie.playerName,
+      teamName: wedgie.teamName,
+      teamAgainstName: wedgie.teamAgainstName,
+      number: wedgie.number,
+      seasonName: wedgie.seasonName,
+      videoUrl: wedgie.videoUrl,
+    })
+    .from(wedgie)
+    .where(sql`json_extract(${wedgie.videoUrl}, '$.cloudinary') IS NOT NULL`)
+    .orderBy(desc(wedgie.wedgieDate));
+}
+
 async function getCachedTotalWedgies() {
   "use cache";
   cacheTag(CACHE_TAGS.WEDGIE_DATA);
-  cacheLife({ revalidate: 120 });
+  cacheLife({ revalidate: 3600 });
 
   const [result] = await db
     .select({ count: count() })
@@ -462,27 +540,11 @@ export const wedgieRouter = createTRPCRouter({
 
   getByPlayer: publicProcedure
     .input(z.object({ player: z.string().min(1) }))
-    .query(async ({ ctx, input }) => {
-      return ctx.db
-        .select()
-        .from(wedgie)
-        .where(eq(wedgie.playerName, input.player));
-    }),
+    .query(({ input }) => getCachedByPlayer(input.player)),
 
   getByType: publicProcedure
     .input(z.object({ type: z.string().min(1) }))
-    .query(async ({ ctx, input }) => {
-      const rows = await ctx.db
-        .select({ wedgieId: wedgieToType.wedgieId })
-        .from(wedgieToType)
-        .innerJoin(typeTable, eq(wedgieToType.typeId, typeTable.id))
-        .where(eq(typeTable.name, input.type));
-
-      if (rows.length === 0) return [];
-
-      const wedgieIds = rows.map((r) => r.wedgieId);
-      return ctx.db.select().from(wedgie).where(inArray(wedgie.id, wedgieIds));
-    }),
+    .query(({ input }) => getCachedByType(input.type)),
 
   getLatest: publicProcedure.query(() => getCachedLatest()),
 
@@ -512,53 +574,15 @@ export const wedgieRouter = createTRPCRouter({
       return created;
     }),
 
-  getSelfHostedVideos: publicProcedure.query(async ({ ctx }) => {
-    const wedgies = await ctx.db
-      .select({
-        id: wedgie.id,
-        wedgieDate: wedgie.wedgieDate,
-        videoUrl: wedgie.videoUrl,
-        playerName: wedgie.playerName,
-        teamName: wedgie.teamName,
-        teamAgainstName: wedgie.teamAgainstName,
-        number: wedgie.number,
-        seasonName: wedgie.seasonName,
-      })
-      .from(wedgie)
-      .where(
-        and(
-          sql`json_extract(${wedgie.videoUrl}, '$.selfHosted') IS NOT NULL`,
-          ne(wedgie.seasonName, "GEMS"),
-        ),
-      );
-
-    return wedgies
-      .filter((w) => !(w.videoUrl as VideoUrls)?.youtube)
-      .sort(
-        (a, b) =>
-          new Date(b.wedgieDate).getTime() - new Date(a.wedgieDate).getTime(),
-      );
-  }),
+  getSelfHostedVideos: publicProcedure.query(() => getCachedSelfHostedVideos()),
 
   getLatestWedgies: publicProcedure.query(() => getCachedLatestWedgies()),
 
   getStats: publicProcedure.query(() => getCachedStats()),
 
-  getCloudinaryWedgies: publicProcedure.query(async ({ ctx }) => {
-    return ctx.db
-      .select({
-        id: wedgie.id,
-        playerName: wedgie.playerName,
-        teamName: wedgie.teamName,
-        teamAgainstName: wedgie.teamAgainstName,
-        number: wedgie.number,
-        seasonName: wedgie.seasonName,
-        videoUrl: wedgie.videoUrl,
-      })
-      .from(wedgie)
-      .where(sql`json_extract(${wedgie.videoUrl}, '$.cloudinary') IS NOT NULL`)
-      .orderBy(desc(wedgie.wedgieDate));
-  }),
+  getCloudinaryWedgies: publicProcedure.query(() =>
+    getCachedCloudinaryWedgies(),
+  ),
 
   getTopStandings: publicProcedure.query(() => getCachedTopStandings()),
 


### PR DESCRIPTION
## Summary
- **Home page dedup** — `StandingsWrapper` was calling `api.wedgie.getStats()` purely to check `currentSeasonWedgies === 0`. Folded that signal into `getTopStandings` as `hasWedgiesThisSeason`, so the home page now hits stats once per render instead of twice.
- **Cache the four uncached public wedgie procedures** — `getByPlayer`, `getByType`, `getSelfHostedVideos`, `getCloudinaryWedgies` all ran a fresh DB query on every client request. Wrapped each in a `"use cache"` helper tagged `WEDGIE_DATA`, matching the existing pattern.
- **Bumped every `WEDGIE_DATA` cacheLife revalidate to 3600s.** Writes already invalidate via `revalidateTag(WEDGIE_DATA, "max")`, so freshness is tag-driven; the prior 60-300s windows just rebuilt the same data on a timer.
- **Batched the live-status update in `/api/external`** — replaced the per-game update loop with two `inArray` updates (one for live=true, one for live=false). Constant round-trips regardless of game count.

## Test plan
- [x] `pnpm lint` clean (only pre-existing warning)
- [x] `pnpm test` — 33 tests pass
- [x] `pnpm build` — succeeds; build output now shows `1h` revalidate on the affected pages
- [ ] After merge: confirm Vercel logs show fewer DB queries on `/`, `/all-wedgies`, `/standings`, and that `/api/external` POSTs continue to refresh the home page within seconds (tag invalidation path)