### PR TITLE
perf: block on next request after wedgie data writes

### DIFF
--- a/src/app/api/external/route.ts
+++ b/src/app/api/external/route.ts
@@ -202,7 +202,7 @@ export async function POST(request: Request) {
     await db.update(global).set(globalUpdate).where(eq(global.id, 1));
   }
 
-  revalidateTag(CACHE_TAGS.WEDGIE_DATA, "max");
+  revalidateTag(CACHE_TAGS.WEDGIE_DATA);
 
   return NextResponse.json({ message: "Data updated successfully" });
 }

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -7,7 +7,10 @@ export const CACHE_TAGS = {
 } as const;
 
 export function invalidateWedgieData() {
-  revalidateTag(CACHE_TAGS.WEDGIE_DATA, "max");
+  // Single-arg form: blocks the next request to refetch fresh data instead of
+  // serving stale via SWR. Deprecated but the only Route-Handler-callable API
+  // that gives read-your-own-writes for the live wedgie counter.
+  revalidateTag(CACHE_TAGS.WEDGIE_DATA);
 }
 
 export function invalidateStoreData() {


### PR DESCRIPTION
## Summary
- Switches `WEDGIE_DATA` tag invalidations (`/api/external` and `invalidateWedgieData()`) from `revalidateTag(tag, "max")` to the single-arg form.
- `"max"` is stale-while-revalidate per the [Next.js 16 docs](https://nextjs.org/docs/app/api-reference/functions/revalidateTag) — the visitor right after a wedgie post sees the old count while the cache refreshes in the background. Not the UX we want for a live counter.
- The single-arg form is documented as deprecated, but it's currently the only Route-Handler-callable invalidation that gives read-your-own-writes. `updateTag` is the non-deprecated alternative but is Server-Actions-only, which doesn't fit the API-key flow on `/api/external`.
- `STORE_DATA` invalidations stay on `"max"` — those don't have the same live-counter sensitivity.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` — 33 tests pass
- [x] `pnpm build` — succeeds
- [ ] After merge: trigger an external POST and confirm the home page updates on the very next visit (not the one after)