### PR TITLE
Show games played when pace tile is hidden

### DIFF
--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -113,7 +113,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
         >
           <div
             className={`flex flex-col items-center justify-center text-center ${
-              showPace ? "w-[100px] md:w-[135px]" : "w-auto"
+              showPace ? "w-[100px] md:w-[135px]" : "w-auto md:w-[140px]"
             }`}
           >
             <div

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -91,7 +91,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
         </div>
       </div>
 
-      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center p-8 md:min-h-[14em]">
+      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center px-8 py-12 md:min-h-[14em] md:py-8">
         {stats.liveGames && (
           <div
             className="absolute bottom-2 left-4 z-10 z-50 flex flex-row items-center justify-center gap-2 rounded-full border border-red-500 bg-red-500/90 px-2 py-1 md:bottom-4 md:px-2 md:py-2"
@@ -106,24 +106,44 @@ export function Stats({ stats, isLoading }: StatsProps) {
             </div>
           </div>
         )}
-        <div className="flex flex-row items-center justify-center gap-5">
-          {showPace && (
-            <div className="flex w-[100px] flex-col items-center justify-center text-center md:w-[135px]">
-              <div className="text-pace-text-mobile text-pink md:text-pace-text w-full leading-none font-black tracking-wider uppercase">
-                Pace
-              </div>
-              <div className="shadow-lg-darkpurple-light text-pace-number-mobile text-yellow md:text-pace-number mt-[-.2em] w-full leading-none font-black">
-                <Counter end={stats.currentPace} />
-              </div>
+        <div
+          className={`flex items-center justify-center gap-2 md:flex-row md:gap-5 ${
+            showPace ? "flex-row" : "flex-col"
+          }`}
+        >
+          <div
+            className={`flex flex-col items-center justify-center text-center ${
+              showPace ? "w-[100px] md:w-[135px]" : "w-auto"
+            }`}
+          >
+            <div
+              className={`text-pink w-full leading-none font-black tracking-wider uppercase ${
+                showPace ? "text-pace-text-mobile md:text-pace-text" : "text-xl"
+              }`}
+            >
+              {showPace ? "Pace" : "Games"}
             </div>
-          )}
+            <div
+              className={`shadow-lg-darkpurple-light text-yellow mt-[-.2em] w-full leading-none font-black ${
+                showPace
+                  ? "text-pace-number-mobile md:text-pace-number"
+                  : "text-5xl"
+              }`}
+            >
+              <Counter end={showPace ? stats.currentPace : stats.gamesPlayed} />
+            </div>
+          </div>
 
           {daysAgo && daysAgo > 0 ? (
             <div
-              className={`flex w-[140px] flex-row items-center justify-center gap-3 ${showPace ? "ml-2" : ""}`}
+              className={`flex w-[140px] flex-row items-center justify-center gap-3 md:ml-2 ${
+                showPace ? "ml-2" : ""
+              }`}
             >
               <div
-                className={`text-center uppercase ${showPace ? "pl-2" : ""}`}
+                className={`text-center uppercase md:pl-2 ${
+                  showPace ? "pl-2" : ""
+                }`}
               >
                 <div className="shadow-lg-darkpurple-light text-yellow text-5xl leading-none font-black">
                   {daysAgo}
@@ -138,10 +158,14 @@ export function Stats({ stats, isLoading }: StatsProps) {
             </div>
           ) : (
             <div
-              className={`flex w-[140px] flex-col items-start justify-start ${showPace ? "ml-2" : ""}`}
+              className={`flex w-[140px] flex-col items-start justify-start md:ml-2 ${
+                showPace ? "ml-2" : ""
+              }`}
             >
               <div
-                className={`text-center text-4xl uppercase ${showPace ? "pl-4" : ""}`}
+                className={`text-center text-4xl uppercase md:pl-4 ${
+                  showPace ? "pl-4" : ""
+                }`}
               >
                 <div className="shadow-lg-darkpurple-light animate-color-shift text-pink leading-none font-black">
                   New

--- a/src/components/home/stats-video-canvas.ts
+++ b/src/components/home/stats-video-canvas.ts
@@ -153,6 +153,21 @@ function drawLogoAndUrlBadge(
   ctx.fillText(urlText, width / 2, buttonY + 34);
 }
 
+function fitNumberFont(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxFontSize: number,
+  maxWidth: number,
+): number {
+  let size = maxFontSize;
+  ctx.font = `900 ${size}px Inter`;
+  while (ctx.measureText(text).width > maxWidth && size > 40) {
+    size -= 8;
+    ctx.font = `900 ${size}px Inter`;
+  }
+  return size;
+}
+
 function setupFrame(
   frame: FrameContext,
   progress: number,
@@ -272,10 +287,20 @@ export function drawFrame(
     ctx.fillStyle = "#EAFF00";
     ctx.fillText(currentPaceValue.toString(), width * 0.25, bottomY + 120);
   } else {
-    ctx.font = "900 120px Inter";
     ctx.fillStyle = "#EAFF00";
     ctx.textAlign = "center";
-    ctx.fillText(currentGamesValue.toString(), width * 0.25, bottomY + 116);
+    const size = fitNumberFont(
+      ctx,
+      stats.gamesPlayed.toString(),
+      120,
+      statBoxWidth - 32,
+    );
+    const yShift = (120 - size) * 0.35;
+    ctx.fillText(
+      currentGamesValue.toString(),
+      width * 0.25,
+      bottomY + 116 - yShift,
+    );
     ctx.font = "700 28px Inter";
     ctx.fillStyle = "#FF00FF";
     ctx.fillText("GAMES", width * 0.25, bottomY + 152);
@@ -376,10 +401,20 @@ export function drawVerticalFrame(
     ctx.fillStyle = "#EAFF00";
     ctx.fillText(currentPaceValue.toString(), width * 0.32, bottomY + 155);
   } else {
-    ctx.font = "900 140px Inter";
     ctx.fillStyle = "#EAFF00";
     ctx.textAlign = "center";
-    ctx.fillText(currentGamesValue.toString(), width * 0.32, bottomY + 140);
+    const size = fitNumberFont(
+      ctx,
+      stats.gamesPlayed.toString(),
+      140,
+      statBoxWidth - 40,
+    );
+    const yShift = (140 - size) * 0.35;
+    ctx.fillText(
+      currentGamesValue.toString(),
+      width * 0.32,
+      bottomY + 140 - yShift,
+    );
     ctx.font = "700 36px Inter";
     ctx.fillStyle = "#FF00FF";
     ctx.fillText("GAMES", width * 0.32, bottomY + 185);


### PR DESCRIPTION
## Summary
- At end of season `currentPace === totalWedgies`, so the homepage Pace tile disappears. Replace it with a `GAMES` tile backed by `stats.gamesPlayed`.
- On mobile the games tile stacks above the days-without/New-wedgie tile; desktop keeps the side-by-side row.
- Update the shareable video generator (horizontal + vertical layouts) to shrink the games number to fit its box, computed once from the final value so the size doesn't shift mid-animation and the visual center stays consistent.

Closes #103

## Test plan
- [ ] Homepage during season: Pace tile renders as before
- [ ] Homepage with `currentPace == totalWedgies`: Games tile shows; mobile stacks (games on top), desktop sits beside days/new-wedgie
- [ ] Shareable video, 3-digit games (e.g. 82): renders at full size, centered
- [ ] Shareable video, 4-digit games (e.g. 1303): shrinks to fit the box, vertically centered, size stays constant during the count-up animation