### PR TITLE
Match Stats bottom-band padding to skeleton

### DIFF
--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -91,7 +91,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
         </div>
       </div>
 
-      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center p-8 md:min-h-[14em]">
+      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center px-8 pt-12 pb-4 md:min-h-[14em] md:p-8">
         {stats.liveGames && (
           <div
             className="absolute bottom-2 left-4 z-10 z-50 flex flex-row items-center justify-center gap-2 rounded-full border border-red-500 bg-red-500/90 px-2 py-1 md:bottom-4 md:px-2 md:py-2"

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -91,7 +91,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
         </div>
       </div>
 
-      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center px-8 py-12 md:min-h-[14em] md:py-8">
+      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center p-8 md:min-h-[14em]">
         {stats.liveGames && (
           <div
             className="absolute bottom-2 left-4 z-10 z-50 flex flex-row items-center justify-center gap-2 rounded-full border border-red-500 bg-red-500/90 px-2 py-1 md:bottom-4 md:px-2 md:py-2"
@@ -107,8 +107,8 @@ export function Stats({ stats, isLoading }: StatsProps) {
           </div>
         )}
         <div
-          className={`flex items-center justify-center gap-2 md:flex-row md:gap-5 ${
-            showPace ? "flex-row" : "flex-col"
+          className={`flex items-center justify-center md:flex-row md:gap-5 ${
+            showPace ? "flex-row gap-5" : "flex-col gap-2"
           }`}
         >
           <div

--- a/src/components/home/StatsSkeleton.tsx
+++ b/src/components/home/StatsSkeleton.tsx
@@ -27,18 +27,6 @@ export function StatsSkeleton() {
       </div>
 
       <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center p-8 md:min-h-[14em]">
-        <div className="flex flex-row items-center justify-center gap-5">
-          <div className="flex w-[100px] flex-col items-center justify-center text-center md:w-[135px]">
-            <div className="text-pace-text-mobile text-pink md:text-pace-text w-full leading-none font-black tracking-wider uppercase">
-              Pace
-            </div>
-            <div className="shadow-lg-darkpurple-light text-pace-number-mobile text-yellow md:text-pace-number mt-[-.2em] w-full leading-none font-black">
-              0
-            </div>
-          </div>
-
-          <div className="ml-2 flex w-[140px] flex-col items-start justify-start"></div>
-        </div>
         {/* cta */}
         <div className="absolute top-0 left-[50%] z-10 translate-x-[-50%] translate-y-[-50%]">
           <Link

--- a/src/components/home/StatsSkeleton.tsx
+++ b/src/components/home/StatsSkeleton.tsx
@@ -26,7 +26,7 @@ export function StatsSkeleton() {
         </div>
       </div>
 
-      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center p-8 md:min-h-[14em]">
+      <div className="bg-darkpurple relative flex min-h-[12em] flex-1 flex-col justify-center px-8 pt-12 pb-4 md:min-h-[14em] md:p-8">
         {/* cta */}
         <div className="absolute top-0 left-[50%] z-10 translate-x-[-50%] translate-y-[-50%]">
           <Link


### PR DESCRIPTION
## Summary
After #110 the `!showPace` mobile container was using `py-12`, which pushed it past `min-h-[12em]` and made the bottom band taller than the `StatsSkeleton` placeholder. On hydration the band visibly grew. Use the same `p-8` the skeleton uses; the column stack still fits within `min-h-[12em]`. Move the smaller `gap-2` onto the `!showPace` column itself so the in-season row keeps `gap-5`.

## Test plan
- [ ] Hard refresh homepage on mobile during the season → no vertical jump when Stats hydrates over the skeleton
- [ ] Hard refresh at end of season (or simulate `currentPace == totalWedgies`) → bottom band stays the same height as the skeleton; games tile + days/new-wedgie sit comfortably
- [ ] Desktop layout unchanged in both states