### PR TITLE
Fix GEMS wedgies showing 1969 date instead of gem emoji

### DIFF
--- a/src/components/home/Wedgie.tsx
+++ b/src/components/home/Wedgie.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { WedgieModal } from "./WedgieModal";
 import { CourtPositionDiagram } from "./CourtPositionDiagram";
 import type { WedgieWithTypes } from "~/types/wedgie";
+import { GEMS_EMOJI, isGemsDate } from "~/utils/formatDate";
 
 interface WedgieProps {
   wedgie: WedgieWithTypes;
@@ -103,12 +104,8 @@ export function Wedgie({
               className={`text-darkpurple group-hover:text-yellow mb-2 leading-none font-black tracking-wide transition-all duration-300 ${sizes.date}`}
               style={{ fontSize: sizes.date }}
             >
-              {new Date(wedgie.wedgieDate).toLocaleDateString("de-DE", {
-                day: "2-digit",
-                month: "2-digit",
-                year: "2-digit",
-              }) === "01.01.70"
-                ? "💎💎💎"
+              {isGemsDate(new Date(wedgie.wedgieDate))
+                ? GEMS_EMOJI
                 : new Date(wedgie.wedgieDate).toLocaleDateString("de-DE", {
                     day: "2-digit",
                     month: "2-digit",

--- a/src/components/home/WedgieInfoPanel.tsx
+++ b/src/components/home/WedgieInfoPanel.tsx
@@ -1,4 +1,5 @@
 import type { Wedgie } from "~/types/wedgie";
+import { GEMS_EMOJI, isGemsDate } from "~/utils/formatDate";
 import { CourtPositionDiagram } from "./CourtPositionDiagram";
 
 interface WedgieInfoPanelProps {
@@ -9,14 +10,8 @@ interface WedgieInfoPanelProps {
 
 function formatDate(date: string | Date) {
   const d = new Date(date);
-  if (
-    d.toLocaleDateString("de-DE", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "2-digit",
-    }) === "01.01.70"
-  ) {
-    return "💎💎💎";
+  if (isGemsDate(d)) {
+    return GEMS_EMOJI;
   }
   return d.toLocaleDateString("en-US", {
     month: "long",

--- a/src/utils/formatDate.test.ts
+++ b/src/utils/formatDate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDate } from "./formatDate";
+import { formatDate, isGemsDate, GEMS_EMOJI } from "./formatDate";
 
 describe("formatDate", () => {
   it("formats a date in uppercase US long format", () => {
@@ -24,5 +24,23 @@ describe("formatDate", () => {
     const date = new Date("2024-06-15T12:00:00Z");
     const result = formatDate(date);
     expect(result).toBe(result.toUpperCase());
+  });
+});
+
+describe("isGemsDate", () => {
+  it("detects the GEMS epoch placeholder regardless of timezone", () => {
+    expect(isGemsDate(new Date("1969-12-31T22:00:00.000Z"))).toBe(true);
+    expect(isGemsDate(new Date(0))).toBe(true);
+  });
+
+  it("returns false for real wedgie dates", () => {
+    expect(isGemsDate(new Date("2024-01-15T20:00:00.000Z"))).toBe(false);
+    expect(isGemsDate(new Date("2000-01-01T00:00:00.000Z"))).toBe(false);
+  });
+});
+
+describe("formatDate with GEMS dates", () => {
+  it("renders the gem emoji for the epoch placeholder", () => {
+    expect(formatDate(new Date("1969-12-31T22:00:00.000Z"))).toBe(GEMS_EMOJI);
   });
 });

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,4 +1,20 @@
+/** Rendered in place of a date for GEMS wedgies, which have no real game date. */
+export const GEMS_EMOJI = "💎💎💎";
+
+/**
+ * GEMS wedgies have no real game date and are stored with an epoch-ish
+ * placeholder (~1969-12-31). Detect via the UTC year so the check is
+ * timezone-independent — comparing a locale-formatted string drifts across
+ * zones (e.g. "31.12.69" vs "01.01.70") and lets the 1969 date leak through.
+ */
+export function isGemsDate(date: Date): boolean {
+  return date.getUTCFullYear() < 2000;
+}
+
 export function formatDate(date: Date): string {
+  if (isGemsDate(date)) {
+    return GEMS_EMOJI;
+  }
   return date
     .toLocaleDateString("en-US", {
       year: "numeric",


### PR DESCRIPTION
## Problem

GEMS wedgies render a `1969` date instead of the `💎💎💎` emoji.

GEMS wedgies have no real game date, so they're stored with an epoch-ish placeholder (`1969-12-31T22:00:00Z`). Two components detected this placeholder by formatting it with the `de-DE` locale and comparing the string against `"01.01.70"`. But the placeholder formats to `"31.12.69"` in any timezone at or behind UTC+2, so the check missed and the raw 1969 date leaked into the UI.

## Fix

Replace the brittle, timezone-dependent string comparison with a `isGemsDate()` helper that checks the UTC year (`< 2000`), making detection timezone-independent. The helper and a `GEMS_EMOJI` constant live in `src/utils/formatDate.ts` and are now shared across:

- `src/components/home/Wedgie.tsx`
- `src/components/home/WedgieInfoPanel.tsx`
- `src/utils/formatDate.ts` (`formatDate` is now gem-aware too)

## Testing

- Added unit tests for `isGemsDate` (epoch placeholder + real dates) and gem rendering in `formatDate`
- `vitest` (7 passed), `tsc --noEmit`, and `oxlint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)