### PR TITLE
Center New wedgie badge and widen mobile Pace tile

### DIFF
--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -113,7 +113,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
         >
           <div
             className={`flex flex-col items-center justify-center text-center ${
-              showPace ? "w-[100px] md:w-[135px]" : "w-auto md:w-[140px]"
+              showPace ? "w-[130px] md:w-[135px]" : "w-auto md:w-[140px]"
             }`}
           >
             <div
@@ -163,7 +163,7 @@ export function Stats({ stats, isLoading }: StatsProps) {
               }`}
             >
               <div
-                className={`text-center text-4xl uppercase md:pl-4 ${
+                className={`mx-auto text-center text-4xl uppercase md:pl-4 ${
                   showPace ? "pl-4" : ""
                 }`}
               >


### PR DESCRIPTION
## Summary
- Add `mx-auto` to the "New wedgie" text block so it centers within its 140px column instead of left-hugging
- Bump the mobile Pace tile from `w-[100px]` to `w-[130px]` so "Pace" + counter sit comfortably alongside the badge

## Test plan
- [ ] Trigger a new wedgie state on home and confirm "New wedgie" sits centered on mobile + desktop
- [ ] With pace tile visible, confirm both tiles read cleanly on a 375px viewport
- [ ] Confirm the 0-days/non-new-wedgie path still renders correctly