### PR TITLE
Fix Instagram OAuth state lost in Link/onClick race

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   jobs:
     - name: ts-lint-format
       glob: "*.{ts,tsx}"
-      run: pnpm exec oxlint --fix {staged_files} && pnpm exec prettier --write {staged_files}
+      run: pnpm exec oxlint --fix --no-error-on-unmatched-pattern {staged_files} && pnpm exec prettier --write {staged_files}
       stage_fixed: true
 
     - name: prettier-other

--- a/src/components/dev/InstagramUploadForm.tsx
+++ b/src/components/dev/InstagramUploadForm.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from "react";
 import { Preview } from "../admin/Preview";
-import Link from "next/link";
 import type { WedgieWithTypes } from "~/types/wedgie";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -222,13 +221,13 @@ export function InstagramUploadForm({ wedgie }: InstagramUploadFormProps) {
 
       {!instagramToken ? (
         <div className="mb-4">
-          <Link
-            href="/api/auth/instagram"
+          <button
+            type="button"
             onClick={handleInstagramConnect}
             className="block w-full rounded bg-blue-500 px-4 py-2 text-center font-bold text-white hover:bg-blue-600"
           >
             Connect Instagram Account
-          </Link>
+          </button>
         </div>
       ) : (
         <div className="space-y-4">


### PR DESCRIPTION
## Summary
- The "Connect Instagram Account" control was both a `<Link href="/api/auth/instagram">` and a button with `onClick={handleInstagramConnect}`. The two raced: the `<Link>` navigated without `state`, the `onClick` set `window.location.href` with `state`. The state-less navigation won, so the OAuth callback redirected to its default (`/admin`) instead of the original wedgie page. `InstagramUploadForm` isn't mounted on `/admin`, so the `instagram_token` URL param was never captured into localStorage — leaving users effectively unable to reconnect after signing out.
- Replaced the `<Link>` with a `<button>` so only the onClick navigation runs, preserving `state` end-to-end.
- Drive-by: passed `--no-error-on-unmatched-pattern` to the pre-commit oxlint step. Editing files under `src/components/dev/**` (which is in `.oxlintrc.json` `ignorePatterns`) previously made oxlint exit non-zero with "No files found to lint", blocking commits to dev-only files.

## Test plan
- [ ] Disconnect Instagram on `/admin/wedgies/<id>`, click Connect, complete OAuth, confirm you land back on the same wedgie page with the form showing connected state
- [ ] Confirm `instagram_token` is in localStorage afterwards and a publish attempt uses it
- [ ] Edit a file under `src/components/dev/` only and confirm `git commit` no longer fails in the ts-lint-format hook