### PR TITLE
Render real newlines in Twitter/Bluesky preview suffix

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,12 @@ pre-commit:
   jobs:
     - name: ts-lint-format
       glob: "*.{ts,tsx}"
-      run: pnpm exec oxlint --fix --no-error-on-unmatched-pattern {staged_files} && pnpm exec prettier --write {staged_files}
+      run: |
+        ox_files=$(printf '%s\n' {staged_files} | grep -vE '^(src/(server|components)/dev/|scripts/)' || true)
+        if [ -n "$ox_files" ]; then
+          pnpm exec oxlint --fix $ox_files || exit 1
+        fi
+        pnpm exec prettier --write {staged_files}
       stage_fixed: true
 
     - name: prettier-other

--- a/src/components/dev/BlueskyPostForm.tsx
+++ b/src/components/dev/BlueskyPostForm.tsx
@@ -9,7 +9,7 @@ export function BlueskyPostForm({ wedgie }: { wedgie: WedgieWithTypes }) {
       wedgie={wedgie}
       platformName="Bluesky"
       endpoint="/api/bluesky/post"
-      previewSuffix="\n\n#WeAreWedgie\n\nWedgieTracker.com"
+      previewSuffix={"\n\n#WeAreWedgie\n\nWedgieTracker.com"}
     />
   );
 }

--- a/src/components/dev/TwitterPostForm.tsx
+++ b/src/components/dev/TwitterPostForm.tsx
@@ -11,7 +11,7 @@ export function TwitterPostForm({ wedgie }: { wedgie: WedgieWithTypes }) {
       wedgie={wedgie}
       platformName="Twitter"
       endpoint="/api/twitter/upload"
-      previewSuffix="\n\nWedgieTracker.com"
+      previewSuffix={"\n\nWedgieTracker.com"}
       headerExtra={<TwitterAuth />}
       preflight={() => {
         const hasCredentials =


### PR DESCRIPTION
## Summary
- `TwitterPostForm` and `BlueskyPostForm` pass `previewSuffix` as a JSX attribute string literal. JSX does not process escape sequences in double-quoted attributes, so `"\n\nWedgieTracker.com"` was stored as literal `\n\n…` and rendered as `\n\n` in the preview block (under `whitespace-pre-wrap`).
- Wrap the suffix in `{…}` to evaluate it as a JS string, so the actual newline characters reach the preview.
- The posted tweet/skeet itself was unaffected — the server builds the message with a template literal in `src/server/dev/twitter.ts` / `src/app/api/bluesky/post/route.ts`, so real newlines have always been sent. This is preview-only.
- Drive-by: the pre-commit `ts-lint-format` job now filters staged files through the same paths `.oxlintrc.json` ignores (`src/{server,components}/dev/**`, `scripts/**`) before invoking oxlint. Without it, editing only files in those paths makes oxlint exit 1 with "No files found to lint" and blocks the commit. Prettier still runs on every staged ts/tsx file.

## Test plan
- [ ] Open a wedgie's Twitter post form, type a message, confirm preview newlines look right (no literal `\n\n`)
- [ ] Same for Bluesky form
- [ ] Edit a non-dev `.tsx` file and confirm the pre-commit hook still lints it via oxlint
- [ ] Edit only a `src/components/dev/*.tsx` file and confirm the hook now passes